### PR TITLE
Simplify Git Pre-Commit hook installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,24 @@ docker run \
 ```
 
 ### Git pre-commit hooks
+
 When working with code, it may not always be the best idea to wait for travis to throw an error if your build failed.
-To automize your development workflow, it may be a good idea to use git pre-commit hooks. 
+To automize your development workflow, it may be a good idea to use git pre-commit hooks.
 
 These little snippets of code are run prior to a commit and can determine whether your commit should be accepted.
-In the case of watchful, a pre-commit hook could look something like this, calling both test and analysis make 
+In the case of `watchful`, a pre-commit hook could look something like this, calling both `test` and `analysis` make
 targets before a commit.
 
 You can install the default pre-commit hook using this command in your watchful root directory:
-```sh 
-cat pre-commit.sh > .git/hooks/pre-commit && chmod u+x .git/hooks/pre-commit
+
+```sh
+cat <<EOS | cat > .git/hooks/pre-commit && chmod a+rx .git/hooks/pre-commit
+#!/usr/bin/env bash
+
+set -euo pipefail
+make analysis test
+
+EOS
 ```
 
 ## License

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail # The hook should fail if the make targets are not executed correctly
-make analysis test # Test the actual code using analysis and test targets


### PR DESCRIPTION
To avoid having too many files in the project root, use a shell heredoc in the `README` to document the Git Pre-Commit hook installation. Basically, we can get rid of a shell script flying around in the root directory and replace it with an one-time copy-n-paste shell command that sets up the file.

Fix Markdown linting issues in the section of the README that covered the pre-commit hook.