### PR TITLE
Introduces merkhet heartbeat

### DIFF
--- a/internal/watchful/cfg/cfg_model.go
+++ b/internal/watchful/cfg/cfg_model.go
@@ -40,8 +40,10 @@ type CloudFoundryConfig struct {
 
 // TaskConfiguration is the configuration for a simply task that is executed against the cloud foundry instance
 type TaskConfiguration struct {
-	Executable string   `yaml:"cmd"`
-	Parameters []string `yaml:"args"`
+	Executable       string   `yaml:"cmd"`
+	Parameters       []string `yaml:"args"`
+	MerkhetWhitelist []string `yaml:"merkhet-whitelist"`
+	MerkhetBlacklist []string `yaml:"merkhet-blacklist"`
 }
 
 // MerkhetConfiguration is the configuration of one merkhet instance running

--- a/internal/watchful/cfg/cfg_test.go
+++ b/internal/watchful/cfg/cfg_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Configuration testing", func() {
 		})
 
 		It("Should read the config from a string yaml", func() {
-			var body string = `---
+			var body = `---
 cf:
   domain: string-yaml-test.com
   api-endpoint: a.test.com

--- a/pkg/merkhet/merkhet_heartbeat.go
+++ b/pkg/merkhet/merkhet_heartbeat.go
@@ -1,0 +1,95 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhet
+
+import (
+	"os"
+	"time"
+)
+
+// Heartbeat defines the heartbeat of a merkhet worker that beats every given duration
+//
+// StartBeating starts the heartbeat
+//
+// StopBeating stops the heartbeat
+//
+// Worker returns the worker instance this heartbeat is working on
+type Heartbeat interface {
+	StartBeating()
+	StopBeating()
+	Worker() Worker
+}
+
+// TickedHeartbeat is a Heartbeat implementation based on a time.Ticker instance
+type TickedHeartbeat struct {
+	Ticker        *time.Ticker
+	WrappedWorker Worker
+	Consumer      Consumer
+	Interval      time.Duration
+	closure       chan os.Signal
+}
+
+// StartBeating starts the heartbeats go routine
+func (t *TickedHeartbeat) StartBeating() {
+	if t.Consumer == nil{
+		return
+	}
+
+	t.Ticker = time.NewTicker(t.Interval)
+	go func() {
+		for {
+			select {
+			case <-t.Ticker.C:
+				t.Consumer.Consume(t.Worker().Merkhet() , t.Worker().ControllerChannel())
+			case <-t.closure:
+				return
+			}
+		}
+	}()
+}
+
+// StopBeating stops the heartbeats go routine
+func (t *TickedHeartbeat) StopBeating() {
+	if t.Ticker == nil {
+		return
+	}
+
+	t.Ticker.Stop()
+
+	t.closure <- os.Kill
+	close(t.closure)
+}
+
+// Worker returns the wrapped worker
+func (t *TickedHeartbeat) Worker() Worker {
+	return t.WrappedWorker
+}
+
+
+// NewTickedHeartbeat creates a new instance of the TickedHeartbeat struct
+func NewTickedHeartbeat(worker Worker, duration time.Duration, consumer Consumer) *TickedHeartbeat {
+	return &TickedHeartbeat{
+		WrappedWorker: worker,
+		Consumer:      consumer,
+		Interval:      duration,
+		closure:       make(chan os.Signal),
+	}
+}

--- a/pkg/merkhet/merkhet_pool.go
+++ b/pkg/merkhet/merkhet_pool.go
@@ -20,18 +20,25 @@
 
 package merkhet
 
+import (
+	"time"
+)
+
 // Pool contains a map of registered merkhets as well as manages them
 //
 // StartWorker pushes a new Merkhet instance to the Pool.
 // This method will also instantly start the worker sub routine
 //
+// StartHeartbeats starts all the heartbeats registered with the running workers
+//
 // Size returns the current size of the Pool
 //
 // ForEach executes the provided function for each Merkhet instance currently managed by the Pool
 //
-// Shutdown shuts the pool and it's workers down
+// Shutdown shuts the pool and it's heartbeats down
 type Pool interface {
-	StartWorker(merkhet Merkhet)
+	StartWorker(m Merkhet , duration time.Duration , heartbeat Consumer)
+	StartHeartbeats()
 	Size() uint
 	ForEach(consumer Consumer)
 	Shutdown()
@@ -39,33 +46,42 @@ type Pool interface {
 
 // SimplePool is a basic implementation of the MerkhetPool interface
 type SimplePool struct {
-	workers []Worker
+	heartbeats []Heartbeat
 }
 
-// StartWorker pushes a new merkhet instance into the Pool
-func (s *SimplePool) StartWorker(m Merkhet) {
+// StartWorker pushes a new merkhet instance into the Pool and starts the worker
+func (s *SimplePool) StartWorker(m Merkhet , duration time.Duration , heartbeat Consumer) {
 	worker := NewMerkhetWorker(m)
 	go worker.StartWorker() // Start the worker instance in a different go routine
 
-	s.workers = append(s.workers, worker)
+	beat := NewTickedHeartbeat(worker, duration, heartbeat)
+	s.heartbeats = append(s.heartbeats, beat)
+}
+
+// StartHeartbeats starts all the heartbeats registered with the running workers
+func (s *SimplePool) StartHeartbeats() {
+	for _, beat := range s.heartbeats {
+		beat.StartBeating()
+	}
 }
 
 // Size returns the size of the pool
 func (s *SimplePool) Size() uint {
-	return uint(len(s.workers))
+	return uint(len(s.heartbeats))
 }
 
 // ForEach executes the provided function for each Merkhet instance currently managed by the pool
 func (s *SimplePool) ForEach(consumer Consumer) {
-	for _, worker := range s.workers {
-		worker.ControllerChannel() <- consumer
+	for _, beat := range s.heartbeats {
+		beat.Worker().ControllerChannel() <- consumer
 	}
 }
 
-// Shutdown shuts the pool and it's workers down
+// Shutdown shuts the pool and it's heartbeats down
 func (s *SimplePool) Shutdown() {
-	for _, worker := range s.workers {
-		close(worker.ControllerChannel())
+	for _, beat := range s.heartbeats {
+		close(beat.Worker().ControllerChannel())
+		beat.StopBeating()
 	}
 }
 

--- a/pkg/merkhet/merkhet_test.go
+++ b/pkg/merkhet/merkhet_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Merkhet code test", func() {
 		})
 
 		It("should have 1 merkhet", func() {
-			pool.StartWorker(merkhet)
+			pool.StartWorker(merkhet , time.Second , nil)
 			Expect(pool.Size()).To(BeNumerically("==", 1))
 		})
 
@@ -59,7 +59,7 @@ var _ = Describe("Merkhet code test", func() {
 				},
 			})
 
-			pool.StartWorker(merkhet)
+			pool.StartWorker(merkhet , time.Second , nil)
 
 			pool.ForEach(ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
 				merkhet.Install()
@@ -76,7 +76,7 @@ var _ = Describe("Merkhet code test", func() {
 				},
 			})
 
-			pool.StartWorker(merkhet)
+			pool.StartWorker(merkhet , time.Second , nil)
 
 			pool.ForEach(ConsumeAsync(func(merkhet Merkhet, relay ControllerChannel) {
 				merkhet.Execute()
@@ -96,7 +96,7 @@ var _ = Describe("Merkhet code test", func() {
 			})
 
 			c := make(chan Result)
-			pool.StartWorker(merkhet)
+			pool.StartWorker(merkhet , time.Second , nil)
 
 			pool.ForEach(ConsumeAsync(func(merkhet Merkhet, relay ControllerChannel) {
 				e := merkhet.Execute()
@@ -115,6 +115,18 @@ var _ = Describe("Merkhet code test", func() {
 			Expect(result.SuccessfulRuns()).To(BeEquivalentTo(1))
 			close(done)
 		}, 5*1000)
+
+		It("should beat correctly" , func(done Done) {
+			pool.StartWorker(merkhet , time.Millisecond , ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
+				merkhet.RecordSuccessfulRun()
+			}))
+			pool.StartHeartbeats()
+			time.Sleep(5 * time.Millisecond)
+			pool.Shutdown()
+
+			Expect(merkhet.BuildResult().SuccessfulRuns()).To(BeEquivalentTo(5))
+			close(done)
+		} , 5 * 1000)
 
 		It("should pass the merkhet test using a flat config", func() {
 			merkhet = NewMerkhetMock(NewFlatConfiguration("test-config", 2), 10, 2, true, callback)

--- a/pkg/merkhet/merkhet_test.go
+++ b/pkg/merkhet/merkhet_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Merkhet code test", func() {
 		})
 
 		It("should have 1 merkhet", func() {
-			pool.StartWorker(merkhet , time.Second , nil)
+			pool.StartWorker(merkhet, time.Second, nil)
 			Expect(pool.Size()).To(BeNumerically("==", 1))
 		})
 
@@ -59,7 +59,7 @@ var _ = Describe("Merkhet code test", func() {
 				},
 			})
 
-			pool.StartWorker(merkhet , time.Second , nil)
+			pool.StartWorker(merkhet, time.Second, nil)
 
 			pool.ForEach(ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
 				merkhet.Install()
@@ -76,7 +76,7 @@ var _ = Describe("Merkhet code test", func() {
 				},
 			})
 
-			pool.StartWorker(merkhet , time.Second , nil)
+			pool.StartWorker(merkhet, time.Second, nil)
 
 			pool.ForEach(ConsumeAsync(func(merkhet Merkhet, relay ControllerChannel) {
 				merkhet.Execute()
@@ -96,7 +96,7 @@ var _ = Describe("Merkhet code test", func() {
 			})
 
 			c := make(chan Result)
-			pool.StartWorker(merkhet , time.Second , nil)
+			pool.StartWorker(merkhet, time.Second, nil)
 
 			pool.ForEach(ConsumeAsync(func(merkhet Merkhet, relay ControllerChannel) {
 				e := merkhet.Execute()
@@ -116,17 +116,19 @@ var _ = Describe("Merkhet code test", func() {
 			close(done)
 		}, 5*1000)
 
-		It("should beat correctly" , func(done Done) {
-			pool.StartWorker(merkhet , time.Millisecond , ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
+		It("should beat correctly", func(done Done) {
+			pool.StartWorker(merkhet, 10*time.Millisecond, ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
 				merkhet.RecordSuccessfulRun()
 			}))
 			pool.StartHeartbeats()
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(time.Second)
+			Expect(len(pool.BeatingHearts())).To(BeEquivalentTo(1))
 			pool.Shutdown()
+			Expect(len(pool.BeatingHearts())).To(BeEquivalentTo(0))
 
-			Expect(merkhet.BuildResult().SuccessfulRuns()).To(BeEquivalentTo(5))
+			Expect(merkhet.BuildResult().SuccessfulRuns()).To(BeNumerically("~", 100, 2))
 			close(done)
-		} , 5 * 1000)
+		}, 10*1000)
 
 		It("should pass the merkhet test using a flat config", func() {
 			merkhet = NewMerkhetMock(NewFlatConfiguration("test-config", 2), 10, 2, true, callback)

--- a/pkg/merkhet/merkhet_worker.go
+++ b/pkg/merkhet/merkhet_worker.go
@@ -29,7 +29,7 @@ type ControllerChannel chan Consumer
 //
 // Merkhet returns the merkhet instance the Worker wraps
 //
-// StartWorker starts the workers listening logic.
+// StartHeartbeat starts the heartbeats listening logic.
 // This has to be called in a different go routine, or it will block the calling routine
 type Worker interface {
 	ControllerChannel() ControllerChannel
@@ -43,7 +43,7 @@ type SimpleWorkerTask struct {
 	master  ControllerChannel
 }
 
-//ControllerChannel returns the controller channel this worker listens on
+// ControllerChannel returns the controller channel this worker listens on
 func (s *SimpleWorkerTask) ControllerChannel() ControllerChannel {
 	return s.master
 }
@@ -53,7 +53,7 @@ func (s *SimpleWorkerTask) Merkhet() Merkhet {
 	return s.merkhet
 }
 
-// StartWorker starts the workers listening logic.
+// StartWorker starts the heartbeats listening logic.
 // This has to be called in a different go routine, or it will block the calling routine
 func (s *SimpleWorkerTask) StartWorker() {
 	for request := range s.ControllerChannel() {


### PR DESCRIPTION
The merkhet workers have to be ticked by a heart. This commit introduces
a new wrapper around the Worker instances that, once started, will
executed a pre-set consumer every x time units.

This heartbeat can be started independently of the worker instances
themselves, to allow a pre-heartbeat setup call.
Heartbeats will be shutdown with the workers on pool#shutdown