### PR TITLE
Implements the curl merkhet

### DIFF
--- a/internal/watchful/merkhets/curl_merkhet.go
+++ b/internal/watchful/merkhets/curl_merkhet.go
@@ -1,0 +1,74 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhets
+
+import (
+	"fmt"
+	"github.com/homeport/watchful/pkg/merkhet"
+	"net/http"
+	"time"
+)
+
+// CurlMerkhet is an implementation of the Merkhet interface that curls against a domain
+type CurlMerkhet struct {
+	Domain        string
+	BaseReference merkhet.Base
+	HTTPClient    *http.Client
+}
+
+// NewDefaultCurlMerkhet creates a new curl merkhet instance
+func NewDefaultCurlMerkhet(domain string, baseReference merkhet.Base) *CurlMerkhet {
+	return NewCurlMerkhet(domain, baseReference, &http.Client{} , 115 * time.Second)
+}
+
+// NewCurlMerkhet creates a new curl merkhet instance
+func NewCurlMerkhet(domain string, baseReference merkhet.Base, httpClient *http.Client, timeout time.Duration) *CurlMerkhet {
+	httpClient.Timeout = timeout
+	return &CurlMerkhet{Domain: domain, BaseReference: baseReference, HTTPClient: httpClient}
+}
+
+// Install installs the merkhet. This does virtually nothing as curl doesn't need setup
+func (m *CurlMerkhet) Install() error {
+	return nil
+}
+
+// PostConnect is called after watchful was authorized against the cloud foundry cluster
+func (m *CurlMerkhet) PostConnect() error {
+	return nil
+}
+
+// Execute executes one single test. This will curl against the domain
+func (m *CurlMerkhet) Execute() error {
+	response, err := m.HTTPClient.Get(m.Domain)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("the domain %s returned status code %d", m.Domain, response.StatusCode)
+	}
+	return nil
+}
+
+// Base returns the merkhet base instance of the curl merkhet
+func (m *CurlMerkhet) Base() merkhet.Base {
+	return m.BaseReference
+}

--- a/internal/watchful/merkhets/merkhet_suite_test.go
+++ b/internal/watchful/merkhets/merkhet_suite_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhets
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/homeport/watchful/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMerkhetImplementations(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t , "watchful internal merkhets")
+}
+
+type MockedServer struct {
+	Router *mux.Router
+	Server *httptest.Server
+}
+
+func (m *MockedServer) Route(path string, handler func(w http.ResponseWriter , r *http.Request)) {
+	m.Router.HandleFunc(path , handler)
+}
+
+func (m *MockedServer) Start() {
+	m.Server.Start()
+}
+
+func NewMockedServer() *MockedServer {
+	router := mux.NewRouter()
+	return &MockedServer{
+		Server: httptest.NewUnstartedServer(router),
+		Router:router,
+	}
+}
+
+type ConsoleLogger struct {
+
+}
+
+func (l *ConsoleLogger) ChannelProvider() logger.ChannelProvider {
+	return nil
+}
+
+func (l *ConsoleLogger) ID() int {
+	return 0
+}
+
+func (l *ConsoleLogger) Name() string {
+	return "console"
+}
+
+func (l *ConsoleLogger) ReportingOn(level logger.LogLevel) logger.ReportingWriter {
+	return &ConsoleLoggerReporter{}
+}
+
+func (l *ConsoleLogger) Write(p []byte, level logger.LogLevel) (n int, err error) {
+	return fmt.Println(string(p))
+}
+
+func (l *ConsoleLogger) WriteString(level logger.LogLevel, s string) error {
+	_, err := fmt.Println(s)
+	return err
+}
+
+type ConsoleLoggerReporter struct {
+
+}
+
+func (r *ConsoleLoggerReporter) ReviewWith(reviewer logger.ReporterReviewer) logger.ReportingWriter {
+	return r
+}
+
+func (r *ConsoleLoggerReporter) Write(p []byte) (n int, err error) {
+	return fmt.Print(string(p))
+}
+
+
+
+
+

--- a/internal/watchful/merkhets/merkhet_test.go
+++ b/internal/watchful/merkhets/merkhet_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhets
+
+import (
+	"github.com/homeport/watchful/pkg/merkhet"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"time"
+)
+
+var _ = Describe("the implemented merkhets should function correctly" , func() {
+
+	var (
+		Server *MockedServer
+		MerkhetBase merkhet.Base
+	)
+
+	_ = BeforeEach(func() {
+		Server = NewMockedServer()
+		Server.Start()
+
+		MerkhetBase = merkhet.NewSimpleBase(&ConsoleLogger{} , merkhet.NewFlatConfiguration("config" , 0))
+	})
+
+	_ = AfterEach(func() {
+		Server.Server.Close()
+		Server.Server = nil
+	})
+
+	_ = It("should curl correctly" , func() {
+		Server.Route("/info" , func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("Hello World"))
+			w.WriteHeader(http.StatusOK)
+		})
+
+		curlMerkhet := NewDefaultCurlMerkhet(Server.Server.URL + "/info", MerkhetBase)
+		Expect(curlMerkhet.Install()).To(BeNil())
+		Expect(curlMerkhet.PostConnect()).To(BeNil())
+		Expect(curlMerkhet.Execute()).To(BeNil())
+	})
+
+	_ = It("should fail curl due to timeout" , func(done Done) {
+		Server.Route("/info" , func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(1 * time.Second)
+		})
+
+		curlMerkhet := NewCurlMerkhet(Server.Server.URL + "/info", MerkhetBase , &http.Client{} , time.Millisecond)
+		Expect(curlMerkhet.Install()).To(BeNil())
+		Expect(curlMerkhet.PostConnect()).To(BeNil())
+		Expect(curlMerkhet.Execute()).To(Not(BeNil()))
+		close(done)
+	} , 5 * 1000)
+
+	_ = It("should fail curl due to wrong status code" , func(done Done) {
+		Server.Route("/info" , func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+
+		curlMerkhet := NewDefaultCurlMerkhet(Server.Server.URL + "/info", MerkhetBase)
+		Expect(curlMerkhet.Install()).To(BeNil())
+		Expect(curlMerkhet.PostConnect()).To(BeNil())
+		Expect(curlMerkhet.Execute()).To(Not(BeNil()))
+		close(done)
+	})
+})

--- a/pkg/merkhet/merkhet.go
+++ b/pkg/merkhet/merkhet.go
@@ -20,10 +20,6 @@
 
 package merkhet
 
-import (
-	"github.com/homeport/watchful/pkg/logger"
-)
-
 // Merkhet defines a runnable measurement task that can be executed during the Cloud Foundry maintenance
 //
 // Install installs the merkhet instance. This method call will be used to setup necessary dependencies of the merkhet
@@ -45,12 +41,7 @@ type Merkhet interface {
 	Install() error
 	PostConnect() error
 	Execute() error
-	BuildResult() Result
-	Configuration() Configuration
-	Logger() logger.Logger
-
-	RecordSuccessfulRun()
-	RecordFailedRun()
+	Base() Base
 }
 
 // Configuration contains the passed configuration values for a Merkhet instance

--- a/pkg/merkhet/merkhet_base.go
+++ b/pkg/merkhet/merkhet_base.go
@@ -1,0 +1,88 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhet
+
+import (
+	"github.com/homeport/watchful/pkg/logger"
+)
+
+// Base represents a merkhet base which contains the values every merkhet needs
+//
+// Logger returns the logger instance the merkhet uses
+//
+// Configuration returns the configuration instance the merkhet uses
+//
+// RecordSuccessfulRun records one new successful run
+//
+// RecordFailedRuns records one new failed run
+//
+// NewResultSet builds a new result set
+type Base interface {
+	Logger() logger.Logger
+	Configuration() Configuration
+	RecordSuccessfulRun()
+	RecordFailedRun()
+	NewResultSet() Result
+}
+
+// SimpleBase is a basic variable driven implementation of the Base interface
+type SimpleBase struct {
+	LoggerReference        logger.Logger
+	ConfigurationReference Configuration
+	SuccessfulRuns         int
+	FailedRun              int
+}
+
+// NewSimpleBase creates a new basic simple base
+func NewSimpleBase(loggerReference logger.Logger, configurationReference Configuration) *SimpleBase {
+	return NewSetSimpleBase(loggerReference , configurationReference, 0 ,0)
+}
+
+// NewSetSimpleBase creates a new simple base with setting failed and successful runs
+func NewSetSimpleBase(loggerReference logger.Logger, configurationReference Configuration, successfulRuns int, failedRun int) *SimpleBase {
+	return &SimpleBase{LoggerReference: loggerReference, ConfigurationReference: configurationReference, SuccessfulRuns: successfulRuns, FailedRun: failedRun}
+}
+
+// Logger returns the logger reference
+func (b *SimpleBase) Logger() logger.Logger {
+	return b.LoggerReference
+}
+
+// Configuration returns the configuration reference of the base
+func (b *SimpleBase) Configuration() Configuration {
+	return b.ConfigurationReference
+}
+
+// RecordSuccessfulRun records a successful run
+func (b *SimpleBase) RecordSuccessfulRun() {
+	b.SuccessfulRuns++
+}
+
+// RecordFailedRun records a failed run
+func (b *SimpleBase) RecordFailedRun() {
+	b.FailedRun++
+}
+
+// NewResultSet builds a new result set instance
+func (b *SimpleBase) NewResultSet() Result {
+	totalRuns := b.FailedRun + b.SuccessfulRuns
+	return NewMerkhetResult(totalRuns, b.FailedRun, b.Configuration().ValidRun(totalRuns, b.FailedRun))
+}

--- a/pkg/merkhet/merkhet_suite_test.go
+++ b/pkg/merkhet/merkhet_suite_test.go
@@ -42,20 +42,13 @@ type MerkhetCallback struct {
 }
 
 type MerkhetMock struct {
-	Config         Configuration
-	LoggerMock     logger.Logger
-	FailedRuns     int
-	SuccessfulRuns int
-	WillExecute    bool
-	Callback       *MerkhetCallback
+	BaseReference Base
+	WillExecute   bool
+	Callback      *MerkhetCallback
 }
 
-func (s *MerkhetMock) RecordSuccessfulRun() {
-	s.SuccessfulRuns = s.SuccessfulRuns + 1
-}
-
-func (s *MerkhetMock) RecordFailedRun() {
-	s.FailedRuns = s.FailedRuns + 1
+func (s *MerkhetMock) Base() Base {
+	return s.BaseReference
 }
 
 func (s *MerkhetMock) Install() error {
@@ -79,26 +72,11 @@ func (s *MerkhetMock) Execute() error {
 	return nil
 }
 
-func (s *MerkhetMock) BuildResult() Result {
-	return NewMerkhetResult(s.SuccessfulRuns, s.FailedRuns, s.Configuration().ValidRun(s.SuccessfulRuns, s.FailedRuns))
-}
-
-func (s *MerkhetMock) Configuration() Configuration {
-	return s.Config
-}
-
-func (s *MerkhetMock) Logger() logger.Logger {
-	return s.LoggerMock
-}
-
 func NewMerkhetMock(config Configuration, totalRuns int, fails int, canExecute bool, callback *MerkhetCallback) *MerkhetMock {
 	return &MerkhetMock{
-		SuccessfulRuns: totalRuns,
-		FailedRuns:     fails,
-		WillExecute:    canExecute,
-		Config:         config,
-		LoggerMock:     NewLoggerMock(),
-		Callback:       callback,
+		BaseReference:NewSetSimpleBase(NewLoggerMock() , config , totalRuns - fails , fails),
+		WillExecute: canExecute,
+		Callback:    callback,
 	}
 }
 
@@ -112,6 +90,10 @@ func (l *LoggerMock) ReportingOn(level logger.LogLevel) logger.ReportingWriter {
 
 func (l *LoggerMock) Name() string {
 	return "LoggerMock"
+}
+
+func (l *LoggerMock) AsPrefix() string {
+	return l.Name()
 }
 
 func (l *LoggerMock) ID() int {

--- a/pkg/merkhet/merkhet_test.go
+++ b/pkg/merkhet/merkhet_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Merkhet code test", func() {
 		})
 
 		It("should have the correct name", func() {
-			Expect(merkhet.Configuration().Name()).To(BeEquivalentTo("test-config"))
+			Expect(merkhet.Base().Configuration().Name()).To(BeEquivalentTo("test-config"))
 		})
 
 		It("should have installed", func() {
@@ -102,12 +102,12 @@ var _ = Describe("Merkhet code test", func() {
 				e := merkhet.Execute()
 				relay <- ConsumeSync(func(merkhet Merkhet, relay ControllerChannel) {
 					if e == nil {
-						merkhet.RecordSuccessfulRun()
+						merkhet.Base().RecordSuccessfulRun()
 					} else {
-						merkhet.RecordFailedRun()
+						merkhet.Base().RecordFailedRun()
 					}
 
-					c <- merkhet.BuildResult()
+					c <- merkhet.Base().NewResultSet()
 				})
 			}))
 
@@ -118,22 +118,22 @@ var _ = Describe("Merkhet code test", func() {
 
 		It("should pass the merkhet test using a flat config", func() {
 			merkhet = NewMerkhetMock(NewFlatConfiguration("test-config", 2), 10, 2, true, callback)
-			Expect(merkhet.BuildResult().Valid()).To(BeTrue())
+			Expect(merkhet.Base().NewResultSet().Valid()).To(BeTrue())
 		})
 
 		It("should not pass the merkhet test using a flat config", func() {
 			merkhet = NewMerkhetMock(NewFlatConfiguration("test-config", 1), 10, 2, true, callback)
-			Expect(merkhet.BuildResult().Valid()).To(BeFalse())
+			Expect(merkhet.Base().NewResultSet().Valid()).To(BeFalse())
 		})
 
 		It("should pass the merkhet test using a percentage config", func() {
 			merkhet = NewMerkhetMock(NewPercentageConfiguration("test-config", 0.2), 10, 2, true, callback)
-			Expect(merkhet.BuildResult().Valid()).To(BeTrue())
+			Expect(merkhet.Base().NewResultSet().Valid()).To(BeTrue())
 		})
 
 		It("should not pass the merkhet test using a percentage config", func() {
 			merkhet = NewMerkhetMock(NewPercentageConfiguration("test-config", 0.1), 10, 2, true, callback)
-			Expect(merkhet.BuildResult().Valid()).To(BeFalse())
+			Expect(merkhet.Base().NewResultSet().Valid()).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
This commit implements the curl merkhet, which is responsible for
curling a provided domain to check http availibility. As this merkhet
does not require a cloud foundry mock, this commit also includes unit
tests for it