### PR TITLE
Removes all console output during unit testing

### DIFF
--- a/internal/watchful/merkhets/merkhet_suite_test.go
+++ b/internal/watchful/merkhets/merkhet_suite_test.go
@@ -21,7 +21,6 @@
 package merkhets
 
 import (
-	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/homeport/watchful/pkg/logger"
 	. "github.com/onsi/ginkgo"
@@ -33,7 +32,7 @@ import (
 
 func TestMerkhetImplementations(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t , "watchful internal merkhets")
+	RunSpecs(t, "watchful internal merkhets")
 }
 
 type MockedServer struct {
@@ -41,8 +40,8 @@ type MockedServer struct {
 	Server *httptest.Server
 }
 
-func (m *MockedServer) Route(path string, handler func(w http.ResponseWriter , r *http.Request)) {
-	m.Router.HandleFunc(path , handler)
+func (m *MockedServer) Route(path string, handler func(w http.ResponseWriter, r *http.Request)) {
+	m.Router.HandleFunc(path, handler)
 }
 
 func (m *MockedServer) Start() {
@@ -53,45 +52,43 @@ func NewMockedServer() *MockedServer {
 	router := mux.NewRouter()
 	return &MockedServer{
 		Server: httptest.NewUnstartedServer(router),
-		Router:router,
+		Router: router,
 	}
 }
 
-type ConsoleLogger struct {
-
+type DevNullLogger struct {
 }
 
-func (l *ConsoleLogger) AsPrefix() string {
+func (l *DevNullLogger) AsPrefix() string {
 	return "[test]"
 }
 
-func (l *ConsoleLogger) ChannelProvider() logger.ChannelProvider {
+func (l *DevNullLogger) ChannelProvider() logger.ChannelProvider {
 	return nil
 }
 
-func (l *ConsoleLogger) ID() int {
+func (l *DevNullLogger) ID() int {
 	return 0
 }
 
-func (l *ConsoleLogger) Name() string {
+func (l *DevNullLogger) Name() string {
 	return "console"
 }
 
-func (l *ConsoleLogger) ReportingOn(level logger.LogLevel) logger.ReportingWriter {
+func (l *DevNullLogger) ReportingOn(level logger.LogLevel) logger.ReportingWriter {
 	return &ConsoleLoggerReporter{}
 }
 
-func (l *ConsoleLogger) Write(p []byte, level logger.LogLevel) (n int, err error) {
-	return fmt.Println(string(p))
+func (l *DevNullLogger) Write(p []byte, level logger.LogLevel) (n int, err error) {
+	return 0, nil
 }
 
-func (l *ConsoleLogger) WriteString(level logger.LogLevel, s string) error {
-	_, err := fmt.Println(s)
+func (l *DevNullLogger) WriteString(level logger.LogLevel, s string) error {
+	_, err := l.Write([]byte(s), level)
 	return err
 }
 
 type ConsoleLoggerReporter struct {
-
 }
 
 func (r *ConsoleLoggerReporter) Refocus(level logger.LogLevel) logger.ReportingWriter {
@@ -103,10 +100,5 @@ func (r *ConsoleLoggerReporter) ReviewWith(reviewer logger.ReporterReviewer) log
 }
 
 func (r *ConsoleLoggerReporter) Write(p []byte) (n int, err error) {
-	return fmt.Print(string(p))
+	return 0, nil
 }
-
-
-
-
-

--- a/internal/watchful/merkhets/merkhet_test.go
+++ b/internal/watchful/merkhets/merkhet_test.go
@@ -39,7 +39,7 @@ var _ = Describe("the implemented merkhets should function correctly", func() {
 		Server = NewMockedServer()
 		Server.Start()
 
-		MerkhetBase = merkhet.NewSimpleBase(&ConsoleLogger{}, merkhet.NewFlatConfiguration("config", 0))
+		MerkhetBase = merkhet.NewSimpleBase(&DevNullLogger{}, merkhet.NewFlatConfiguration("config", 0))
 	})
 
 	_ = AfterEach(func() {
@@ -49,8 +49,8 @@ var _ = Describe("the implemented merkhets should function correctly", func() {
 
 	_ = It("should curl correctly", func() {
 		Server.Route("/info", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("Hello World"))
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Hello World"))
 		})
 
 		curlMerkhet := NewDefaultCurlMerkhet(Server.Server.URL+"/info", MerkhetBase, NewMutexSingleAppProvider(nil, "", ""))

--- a/pkg/logger/logger_suite_test.go
+++ b/pkg/logger/logger_suite_test.go
@@ -54,3 +54,16 @@ func (p *PipelineMock) Observer(o PipelineObserver) {
 func (p *PipelineMock) Location() *time.Location {
 	return time.Local
 }
+
+// DevNullLogger is a simple non recoding logger that discards all content
+type DevNullLogger struct {
+}
+
+func (d *DevNullLogger) Write(p []byte) (n int, err error) {
+	return 0 , nil
+}
+
+func NewDevNullLogger() *DevNullLogger {
+	return &DevNullLogger{}
+}
+

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -21,7 +21,6 @@
 package logger_test
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -151,7 +150,7 @@ var _ = Describe("Logger code test", func() {
 			group := NewGroupContainer().NewGroup(logger).NewGroup(other)
 
 			p := NewSplitPipeline(NewSplitPipelineConfig(true, time.FixedZone("UTC", 0), 80,
-				group, true), os.Stdout) // 200 is the fixed size of a terminal this thing will use, as ginkgo overwrites it
+				group, true), NewDevNullLogger()) // 200 is the fixed size of a terminal this thing will use, as ginkgo overwrites it
 			c := NewLoggerCluster(p, channelProvider, time.Second)
 			p.Observer(func(s string) {
 				if strings.Contains(s, "done") {


### PR DESCRIPTION
Prior to this commit both the logger pipeline as well as the curl
merkhet would print their result to the os.stdout stream, which made the
ginkgo output more verbose. This commit removes that overload by
redirecting the output to a /dev/null like logger