### PR TITLE
Add Go version 1.12 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: go
 go:
   - 1.11.x
+  - 1.12.x
 
 install:
   - curl -sL https://raw.githubusercontent.com/homeport/pina-golada/master/scripts/download-latest.sh | bash -s v1.0.0


### PR DESCRIPTION
Add Go version 1.12 to Travis configuration.