### PR TITLE
Prints the entire merkhet result log

### DIFF
--- a/internal/watchful/services/main_service.go
+++ b/internal/watchful/services/main_service.go
@@ -179,7 +179,8 @@ func (e *MainService) Execute() error {
 						result.SuccessfulRuns(), result.TotalRuns()))
 					future.Complete(nil)
 				}
-			})).FirstError(); err != nil {
+			})).Wait().FirstError(); err != nil {
+				watchfulLogger.WriteString(logger.Error , "A merkhet result was not valid!")
 				shutdownNotifier <- &ErrorSignal{InnerError: errors.Wrap(err, fmt.Sprintf("Faliure in merkhet for task #%d", taskIndex))} // Shutdown with the given error
 				return
 			}

--- a/pkg/merkhet/merkhet_pool.go
+++ b/pkg/merkhet/merkhet_pool.go
@@ -113,11 +113,12 @@ func (s *SimplePool) ForEach(c Consumer) (output ConsumerResult) {
 
 // Shutdown shuts the pool and it's heartbeats down
 func (s *SimplePool) Shutdown() {
+	for _, beat := range s.heartbeats {
+		beat.StopBeating()
+	}
 	s.TaskWaitGroup().Wait()
-
 	for _, beat := range s.heartbeats {
 		close(beat.Worker().ControllerChannel().C)
-		beat.StopBeating()
 	}
 }
 

--- a/pkg/merkhet/merkhet_test.go
+++ b/pkg/merkhet/merkhet_test.go
@@ -61,10 +61,11 @@ var _ = Describe("Merkhet code test", func() {
 
 			pool.StartWorker(merkhet, time.Second, nil)
 
-			pool.ForEach(ConsumeSync(func(m Merkhet, future Future) {
+			err := pool.ForEach(ConsumeSync(func(m Merkhet, future Future) {
 				future.Complete(m.Install())
-			}))
+			})).Wait().FirstError()
 
+			Expect(err).To(BeNil())
 			pool.Shutdown()
 		})
 


### PR DESCRIPTION
This commit now waits on every merkhet result task to finish before
terminating the routine itself. This will therefore print every merkhet
result not just the first failing.

This commit also fixes the issue of merkhets starting when the pool is
about to shutdown, as the pool would wait for all merkhets to finish
their current task while not closing the heartbeats prior to that which
lead to an endless loop in the worst case.

This PR fixes #54 